### PR TITLE
Date range2 did NOT completely contain range1 as the test was intended.

### DIFF
--- a/java/src/test/java/com/sling/daterange/OverlapFinderTest.java
+++ b/java/src/test/java/com/sling/daterange/OverlapFinderTest.java
@@ -66,8 +66,8 @@ public class OverlapFinderTest {
 
     @Test
     public void testRangeTwoCompletelyContainsRangeOne() throws Exception {
-        DateRange range2 = new DateRange(sevenDaysAgo, sevenDaysFuture);
-        DateRange range1 = new DateRange(now, fourteenDaysFuture);
+        DateRange range2 = new DateRange(sevenDaysAgo, fourteenDaysFuture);
+        DateRange range1 = new DateRange(now, sevenDaysFuture);
         DateRange expected = new DateRange(now, sevenDaysFuture);
         OverlapFinder finder = new OverlapFinder();
         DateRange actual = finder.findOverlap(range1, range2);


### PR DESCRIPTION
During an interview @guylaw and I were bewildered to find this test passing when the code didn't appear as thought it should pass.