### PR TITLE
Java source/target 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ The following languages may one day get support:
  - F#
 
 No plans exist to develop tests for these at the moment.
+
+## Setup C#
+
+```
+brew update
+brew tap caskroom/cask
+brew cask install dotnet
+```
+
+Install the dotnet sdk from https://dotnet.microsoft.com/download
+
+Open Visual Studio Code and follow the prompts to add extensions for C#.
+
+Run or debug tests in VSCode. Or run them at the command-line with `dotnet test`.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,6 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
   <groupId>com.sling.daterange</groupId>
   <artifactId>date-range</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
Hi Landon, we had a little snag with the java tests this morning. I believe this fixes it to allow `mvn test`